### PR TITLE
Fix dockerfile to copy to config/lib in the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN mkdir config models lora
 COPY requirements.txt .
 #RUN --mount=type=cache,target=/root/.cache/pip pip install -r requirements.txt
 RUN pip --no-cache install -r requirements.txt
-COPY config/lib /app/config/
+COPY config /app/config
 COPY *.py *.json LICENSE /app/
 
 ENV CLI_COMMAND="python images.py"


### PR DESCRIPTION
With `COPY`, docker's behavior is to copy the _contents_ of the directory. This means that as written, the dockerfile copies the contents of `config/lib` to `config/` in the container. This results in the following exception:

```bash
FileNotFoundError: [Errno 2] No such file or directory: 'config/lib/flux.1-schnell.json'
```

because the config files end up in `config/` not `config/lib`. This PR fixes this issue copying the contents of `config` instead so that the config files end up in `config/lib/` like they are in the repo.